### PR TITLE
Adding commandline option -u for radiant-try-event to use UART instea…

### DIFF
--- a/record_data.py
+++ b/record_data.py
@@ -1,3 +1,6 @@
+import signal
+signal.signal(signal.SIGINT, signal.SIG_DFL)  # allows to close matplotlib window with CTRL+C from terminal
+
 import argparse
 import matplotlib.pyplot as plt
 
@@ -14,19 +17,33 @@ parser.add_argument(
     default=1,
     help="number of events to record",
 )
+
+parser.add_argument(
+    "-c",
+    "--channel",
+    type=int,
+    default=None,
+    help="Plot certain channel. If None plot all channels. (Default: None)",
+)
+
+parser.add_argument('-u', "--use_UART", action="store_true", help="Use UART, not GPIO to check for events")
 args = parser.parse_args()
 
 stationrc.common.setup_logging()
 
 station = stationrc.remote_control.VirtualStation()
 
-data = station.daq_record_data(num_events=args.num_events, force_trigger=True)
+data = station.daq_record_data(num_events=args.num_events, force_trigger=True, use_uart=args.use_UART)
 
 for ev in data["data"]["WAVEFORM"]:
     fig = plt.figure()
     ax = fig.subplots()
-    for ch, wvf in enumerate(ev["radiant_waveforms"]):
-        ax.plot(wvf, label=f"ch. {ch}")
+    if args.channel is None:
+        for ch, wvf in enumerate(ev["radiant_waveforms"]):
+            ax.plot(wvf, label=f"ch. {ch}")
+    else:
+        ax.plot(ev["radiant_waveforms"][args.channel], label=f"ch. {args.channel}")
+        
     ax.legend()
     ax.set_title(f"Event: {ev['event_number']}")
     ax.set_xlabel("Sample")

--- a/stationrc/bbb/Station.py
+++ b/stationrc/bbb/Station.py
@@ -41,6 +41,7 @@ class Station(object):
         trigger_coincidence=1,
         force_trigger=False,
         force_trigger_interval=1,
+        use_uart=False
     ):
         if num_events <= 0:
             self.logger.error("Infinite recording not supported.")
@@ -61,6 +62,10 @@ class Station(object):
         ]
         if force_trigger:
             cmd += ["-f", "-I", f"{force_trigger_interval}"]
+            
+        if use_uart:
+            cmd += ["-u"]
+  
         self.acq_proc = stationrc.common.Executor(
             cmd=cmd,
             logger=self.logger,

--- a/stationrc/remote_control/VirtualStation.py
+++ b/stationrc/remote_control/VirtualStation.py
@@ -17,9 +17,9 @@ class VirtualStation(object):
 
         self.context = zmq.Context()
         self.socket = self.context.socket(zmq.REQ)
-        self.socket.connect(
-            f'tcp://{self.station_conf["remote_control"]["host"]}:{self.station_conf["remote_control"]["port"]}'
-        )
+        socket = f'tcp://{self.station_conf["remote_control"]["host"]}:{self.station_conf["remote_control"]["port"]}'
+        self.logger.debug(f'Connect to socket: "{socket}".')
+        self.socket.connect(socket)
 
     def daq_record_data(
         self,
@@ -29,6 +29,7 @@ class VirtualStation(object):
         trigger_coincidence=1,
         force_trigger=False,
         force_trigger_interval=1,
+        use_uart=False
     ):
         return self._send_command(
             "station",
@@ -40,6 +41,7 @@ class VirtualStation(object):
                 "trigger_coincidence": trigger_coincidence,
                 "force_trigger": force_trigger,
                 "force_trigger_interval": force_trigger_interval,
+                "use_uart": use_uart
             },
         )
 


### PR DESCRIPTION
…d of GPIO. Also add option to plot single channel.

Hi @tikarg, I think most changes are not "controversial". If you want me for example to remove the `import signal` block in the record_data script I can do so