### PR TITLE
Enable multiconnections

### DIFF
--- a/bring_up.py
+++ b/bring_up.py
@@ -20,17 +20,25 @@ parser.add_argument(
     help="If true, request and store pedestals.",
 )
 
+parser.add_argument(
+    "--host", "--hosts",
+    dest="hosts",
+    type=str, default=[None],
+    nargs="+",
+    help="Specify ip address of host. If `None`, use ip from config in stationrc.")
+
 args = parser.parse_args()
 
 stationrc.common.setup_logging()
 
-station = stationrc.remote_control.VirtualStation()
+for host in args.hosts:
+    station = stationrc.remote_control.VirtualStation(host=host)
 
-try:
-    station.radiant_setup(version=args.version)
-except KeyboardInterrupt:
-    sys.exit()
+    try:
+        station.radiant_setup(version=args.version)
+    except KeyboardInterrupt:
+        sys.exit()
 
-if args.pedestals:
-    with open(f"peds_{station.get_radiant_board_mcu_uid():032x}.json", "w") as f:
-        json.dump(station.radiant_pedestal_get(), f)
+    if args.pedestals:
+        with open(f"peds_{station.get_radiant_board_mcu_uid():032x}.json", "w") as f:
+            json.dump(station.radiant_pedestal_get(), f)

--- a/controller-board-rc.py
+++ b/controller-board-rc.py
@@ -8,17 +8,19 @@ parser = argparse.ArgumentParser()
 parser.add_argument("command", type=str, help="command to be sent to station")
 
 parser.add_argument(
-    "--host",
-    type=str,
-    default=None,
-    help="Specify ip address of host. If `None`, use ip from `virtual_station_config.json`."
-)
+    "--host", "--hosts",
+    dest="hosts",
+    type=str, default=[None],
+    nargs="+",
+    help="Specify ip address of host. If `None`, use ip from config in stationrc.")
+
 
 args = parser.parse_args()
 
 stationrc.common.setup_logging()
 
-station = stationrc.remote_control.VirtualStation(host=args.host)
+for host in args.hosts:
+    station = stationrc.remote_control.VirtualStation(host=host)
 
-data = station.rc.send_command("controller-board", args.command)
-print(data)
+    data = station.rc.send_command("controller-board", args.command)
+    print(data)

--- a/controller-board-rc.py
+++ b/controller-board-rc.py
@@ -6,11 +6,19 @@ import stationrc.remote_control
 
 parser = argparse.ArgumentParser()
 parser.add_argument("command", type=str, help="command to be sent to station")
+
+parser.add_argument(
+    "--host",
+    type=str,
+    default=None,
+    help="Specify ip address of host. If `None`, use ip from `virtual_station_config.json`."
+)
+
 args = parser.parse_args()
 
 stationrc.common.setup_logging()
 
-station = stationrc.remote_control.VirtualStation()
+station = stationrc.remote_control.VirtualStation(host=args.host)
 
 data = station.rc.send_command("controller-board", args.command)
 print(data)

--- a/initial_tune.py
+++ b/initial_tune.py
@@ -65,11 +65,18 @@ parser.add_argument(
     default=[]
 )
 
+parser.add_argument(
+    "--host",
+    type=str,
+    default=None,
+    help="Specify ip address of host. If `None`, use ip from `virtual_station_config.json`."
+)
+
 args = parser.parse_args()
 
 stationrc.common.setup_logging()
 
-station = stationrc.remote_control.VirtualStation()
+station = stationrc.remote_control.VirtualStation(host=args.host)
 
 if args.reset_radiant:
     station.reset_radiant_board()

--- a/stationrc/remote_control/RemoteControl.py
+++ b/stationrc/remote_control/RemoteControl.py
@@ -54,7 +54,7 @@ class RemoteControl(object):
                 self.logger.info(f"Listening to logging on port {logger_port}")
 
                 # configure how many client the server can listen simultaneously
-                self.logger_socket.listen(1)
+                self.logger_socket.listen(10)
 
                 self.listening = True
                 self.thr_logger = threading.Thread(

--- a/stationrc/remote_control/RemoteControl.py
+++ b/stationrc/remote_control/RemoteControl.py
@@ -47,22 +47,24 @@ class RemoteControl(object):
             self.logger.info(f"Connect to socket: '{socket_add}'.")
             self.socket.connect(socket_add)
 
-            # self.logger_socket = socket.create_server((get_ip(), logger_port), reuse_port=True)  # get instance
-            self.logger_socket = socket.socket()
-            self.logger_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            self.logger_socket.bind(("", logger_port))  # bind to all interfaces
-            self.logger.info(f"Listening to logging on port {logger_port}")
+            try:
+                self.logger_socket = socket.socket()
+                self.logger_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                self.logger_socket.bind(("", logger_port))  # bind to all interfaces
+                self.logger.info(f"Listening to logging on port {logger_port}")
 
-            # configure how many client the server can listen simultaneously
-            self.logger_socket.listen(1)
+                # configure how many client the server can listen simultaneously
+                self.logger_socket.listen(1)
 
-            self.listening = True
-            self.thr_logger = threading.Thread(
-                target=self.receive_logger,  daemon=True)  # daemon=True -> dies when program finishes
-            self.thr_logger.start()
+                self.listening = True
+                self.thr_logger = threading.Thread(
+                    target=self.receive_logger,  daemon=True)  # daemon=True -> dies when program finishes
+                self.thr_logger.start()
 
-            self._logger_port = logger_port
-            self._has_set_logger = False
+                self._logger_port = logger_port
+                self._has_set_logger = False
+            except OSError:
+                self._has_set_logger = True  # do not set logger handler on the remote side
 
     def send_command(self, device, cmd, data=None):
         tx = {"device": device, "cmd": cmd}

--- a/stationrc/remote_control/VirtualStation.py
+++ b/stationrc/remote_control/VirtualStation.py
@@ -9,18 +9,22 @@ from .RemoteControl import RemoteControl, get_ip
 
 
 class VirtualStation(object):
-    def __init__(self, force_run_mode=None):
+    def __init__(self, force_run_mode=None, host=None):
         """
 
         Parameters
         ----------
 
-        force_run_mode: None or str (Default: None)
+        force_run_mode: str, optional (Default: None)
             Force to run locally or remotely.
 
                 * None: Automatically determine whether radiant is available
                 * "local": Force to run locally
                 * "remote": Force to run remotely
+
+        host: str, optional (Default: None)
+            Specify the remote host ip address. If `None`, use ip
+            from config file.
         """
         self.logger = logging.getLogger("VirtualStation")
 
@@ -47,8 +51,9 @@ class VirtualStation(object):
         if self.station_conf is None:
             raise FileNotFoundError("Could not find a config file.")
 
+        remote_host = host or self.station_conf["remote_control"]["host"]
         self.rc = RemoteControl(
-            self.station_conf["remote_control"]["host"],
+            remote_host,
             self.station_conf["remote_control"]["port"],
             self.station_conf["remote_control"]["logger_port"],
             run_local=run_local


### PR DESCRIPTION
This PR allow to initialize mutliple `VirtualStations` all connecting to different remote hosts. The different remote hosts addresses are specified via the command line. The default still only reads the address out of the config file. 

In case one tries to connect to several hosts, while all VirtualStations still exist we only open a logger socket with the first VirtualStation (however, this one should catch msg from all stations?)