### PR TITLE
New loading logic

### DIFF
--- a/stationrc/bbb/Station.py
+++ b/stationrc/bbb/Station.py
@@ -34,7 +34,10 @@ class Station(object):
 
             self.thr_rc = threading.Thread(
                 target=Station._receive_remote_command, args=[self])
+
             self.thr_rc.start()
+
+            self._radiant_board.calib.load(self._radiant_board.uid())
 
     @property
     def radiant_board(self):

--- a/stationrc/remote_control/VirtualStation.py
+++ b/stationrc/remote_control/VirtualStation.py
@@ -10,7 +10,7 @@ from .utils import convert_alias_to_ip
 
 
 class VirtualStation(object):
-    def __init__(self, force_run_mode=None, host=None):
+    def __init__(self, load_calibration=True, force_run_mode=None, host=None):
         """
 
         Parameters
@@ -63,6 +63,9 @@ class VirtualStation(object):
         self.radiant_low_level_interface = RADIANTLowLevelInterface(
             remote_control=self.rc
         )
+
+        if load_calibration:
+            self.radiant_low_level_interface.calibration_load()
 
     def daq_record_data(
         self,


### PR DESCRIPTION
This PR (including changes in new branch of submodule) will slightly change the logic when the calibration is loaded (and the lab4d updated). 

So far that happens when a radiant object is created. Now that is not the case anymore which allows operations which not require the calibration to run faster. However, when one starts a stationrc deamon on the BBB the calib is explicitly loaded which maintains the current behaviour. Also the two scripts `bring_up` and `initial_tune` load the calibration! 