### PR TITLE
Add python support for reading binary data with 2025 firmware.

### DIFF
--- a/stationrc/common/RNOGDataFile.py
+++ b/stationrc/common/RNOGDataFile.py
@@ -22,6 +22,7 @@ class PacketType(enum.Enum):
 class RNOGDataFile(RawDataFile):
     RNO_G_NUM_LT_CHANNELS = 4
     RNO_G_NUM_RADIANT_CHANNELS = 24
+    RNO_G_NUM_LT_BEAMS = 12
     RNO_G_LAB4D_NSAMPLES = 4096
     RNO_G_PEDESTAL_NSAMPLES = RNO_G_LAB4D_NSAMPLES
 
@@ -45,6 +46,7 @@ class RNOGDataFile(RawDataFile):
     def read_packet(self, type, version):
         version = f"v{version}"
 
+
         if type not in self.data_format:
             raise ValueError(f"Packet type {type} not supported.")
 
@@ -53,6 +55,7 @@ class RNOGDataFile(RawDataFile):
 
         data = {"type": type}
         for field in self.data_format[type][version]:
+
             if len(field) == 2:
                 fcn = getattr(self, f"read_{field[1]}")
                 data[field[0]] = fcn()

--- a/stationrc/common/RNOGDataFile.py
+++ b/stationrc/common/RNOGDataFile.py
@@ -100,3 +100,6 @@ class RNOGDataFile(RawDataFile):
 
     def read_rno_g_radiant_trigger_config(self):
         return self.read_packet("rno_g_radiant_trigger_config", version=0)
+
+    def read_rno_g_lt_phased_trigger_config(self):
+        return self.read_packet("rno_g_lt_phased_trigger_config", version=0)

--- a/stationrc/common/conf/rno-g_data_format.json
+++ b/stationrc/common/conf/rno-g_data_format.json
@@ -59,6 +59,80 @@
                 "uint8",
                 [7]
             ]
+        ],
+        "v6": [
+            [
+                "when_radiant",
+                "double"
+            ],
+            [
+                "when_lt",
+                "double"
+            ],
+            [
+                "radiant_thresholds",
+                "uint32",
+                ["RNO_G_NUM_RADIANT_CHANNELS"]
+            ],
+            [
+                "radiant_scalers",
+                "uint16",
+                ["RNO_G_NUM_RADIANT_CHANNELS"]
+            ],
+            [
+                "radiant_prescalers",
+                "uint8",
+                ["RNO_G_NUM_RADIANT_CHANNELS"]
+            ],
+            [
+                "radiant_scaler_period",
+                "float"
+            ],
+            [
+                "lt_coinc_trigger_thresholds",
+                "uint8",
+                ["RNO_G_NUM_LT_CHANNELS"]
+            ],
+            [
+                "lt_coinc_servo_thresholds",
+                "uint8",
+                ["RNO_G_NUM_LT_CHANNELS"]
+            ],
+            [
+                "lt_phased_trigger_thresholds",
+                "uint8",
+                ["RNO_G_NUM_LT_BEAMS"]
+            ],
+            [
+                "lt_phased_servo_thresholds",
+                "uint8",
+                ["RNO_G_NUM_LT_BEAMS"]
+            ],
+            [
+                "lt_phased_threshold_offset",
+                "uint16"
+            ],
+            [
+                "lt_scalers",
+                "rno_g_lt_scalers"
+            ],
+            [
+                "radiant_voltages",
+                "rno_g_radiant_voltages"
+            ],
+            [
+                "cal",
+                "rno_g_calpulser_info"
+            ],
+            [
+                "station",
+                "uint8"
+            ],
+            [
+                "_padding?",
+                "uint8",
+                [7]
+            ]
         ]
     },
     "RNO-G_CALPULSER_INFO": {
@@ -67,6 +141,28 @@
                 "_bitfield_stuff",
                 "uint16",
                 [3]
+            ]
+        ],
+        "v1": [
+            [
+                "T_times_16",
+                "uint16"
+            ],
+            [
+                "mode",
+                "uint8"
+            ],
+            [
+                "enabled",
+                "uint8"
+            ],
+            [
+                "atten_times_2",
+                "uint8"
+            ],
+            [
+                "out",
+                "uint8"
             ]
         ]
     },

--- a/stationrc/common/conf/rno-g_data_format.json
+++ b/stationrc/common/conf/rno-g_data_format.json
@@ -321,6 +321,109 @@
                 "trig_conf",
                 "rno_g_radiant_trigger_config"
             ]
+        ],
+        "v2": [
+            [
+                "event_number",
+                "uint32"
+            ],
+            [
+                "trigger_number",
+                "uint32"
+            ],
+            [
+                "run_number",
+                "uint32"
+            ],
+
+            [
+                "trigger_mask",
+                "uint32"
+            ],
+            [
+                "trigger_value",
+                "uint32"
+            ],
+            [
+                "sys_clk",
+                "uint32"
+            ],
+
+
+            [
+                "pps_count",
+                "uint32"
+            ],
+            [
+                "readout_time_secs",
+                "uint32"
+            ],
+            [
+                "readout_time_nsecs",
+                "uint32"
+            ],
+            [
+                "readout_elapsed_nsecs",
+                "uint32"
+            ],
+            [
+                "sysclk_last_pps",
+                "uint32"
+            ],
+            [
+                "sysclk_last_last_pps",
+                "uint32"
+            ],
+
+            [
+                "raw_tinfo",
+                "uint32"
+            ],
+            [
+                "raw_evstatus",
+                "uint32"
+            ],
+            [
+                "station_number",
+                "uint8"
+            ],
+            [
+                "trigger_type",
+                "uint8"
+            ],
+            [
+                "flags",
+                "uint8"
+            ],
+            [
+                "pretrigger_windows",
+                "uint8"
+            ],
+            [
+                "radiant_start_windows",
+                "uint8",
+                ["RNO_G_NUM_RADIANT_CHANNELS", 2]
+            ],
+            [
+                "radiant_nsamples",
+                "uint16"
+            ],
+            [
+                "lt_nsamples",
+                "uint16"
+            ],
+            [
+                "simple_trig_conf",
+                "rno_g_lt_simple_trigger_config"
+            ],
+            [
+                "trig_conf",
+                "rno_g_radiant_trigger_config"
+            ],
+            [
+                "phased_trig_conf",
+                "rno_g_lt_phased_trigger_config"
+            ]
         ]
     },
     "rno_g_lt_simple_trigger_config": {
@@ -338,6 +441,18 @@
                 "_bitfield_stuff",
                 "uint8",
                 [19]
+            ]
+        ]
+    },
+    "rno_g_lt_phased_trigger_config": {
+        "v0": [
+            [
+                "beam_mask",
+                "uint16"
+            ],
+            [
+                "phased_threshold_offset",
+                "uint16"
             ]
         ]
     },


### PR DESCRIPTION
Cleaned up version of #25.

Reading the v6 daqstatus does not work yet. @ryankrebs016 or @tikarg any idea? (Is there a way to read enums)?